### PR TITLE
[activatePool-stream-init] initializing stream in /activatepool

### DIFF
--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -146,7 +146,9 @@ export class TokensService {
   }
 
   async activatePool(dto: TokenPoolActivate) {
-    this.stream = await this.eventstream.createOrUpdateStream(this.topic);
+    if(this.stream === undefined) {
+      this.stream = await this.eventstream.createOrUpdateStream(this.topic);
+    }
     await Promise.all([
       this.eventstream.getOrCreateSubscription(
         `${this.baseUrl}/${this.instancePath}`,

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -104,9 +104,6 @@ export class TokensService {
    */
   async init() {
     this.stream = await this.eventstream.createOrUpdateStream(this.topic);
-    console.log('init');
-    console.log(this.topic);
-    console.log(this.stream);
     await this.eventstream.getOrCreateSubscription(
       this.instanceUrl,
       this.stream.id,

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -104,6 +104,9 @@ export class TokensService {
    */
   async init() {
     this.stream = await this.eventstream.createOrUpdateStream(this.topic);
+    console.log('init');
+    console.log(this.topic);
+    console.log(this.stream);
     await this.eventstream.getOrCreateSubscription(
       this.instanceUrl,
       this.stream.id,
@@ -146,6 +149,7 @@ export class TokensService {
   }
 
   async activatePool(dto: TokenPoolActivate) {
+    this.stream = await this.eventstream.createOrUpdateStream(this.topic);
     await Promise.all([
       this.eventstream.getOrCreateSubscription(
         `${this.baseUrl}/${this.instancePath}`,


### PR DESCRIPTION
When a FireFly stack goes down and comes back up, the eventstream is not always re-initialized, resulting in errors when sending a `POST` to `/activatepool`. This fix ensures that a stream is created before trying to activate pools